### PR TITLE
Remove Amharic from the language menu.

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -81,7 +81,6 @@ go.utils = {
         var lang_map = {
             en: 'english',
             fr: 'french',
-            am: 'amharic',
             sw: 'swahili',
             so: 'somali'
         };

--- a/go-app-ussd.js
+++ b/go-app-ussd.js
@@ -81,7 +81,6 @@ go.utils = {
         var lang_map = {
             en: 'english',
             fr: 'french',
-            am: 'amharic',
             sw: 'swahili',
             so: 'somali'
         };
@@ -928,7 +927,6 @@ go.app = function() {
                 choices: [
                     new Choice('en', $("English")),
                     new Choice('fr', $("French")),
-                    new Choice('am', $("Amharic")),
                     new Choice('sw', $("Swahili")),
                     new Choice('so', $("Somali")),
                 ],
@@ -1772,7 +1770,6 @@ go.app = function() {
                 choices: [
                     new Choice('en', $("English")),
                     new Choice('fr', $("French")),
-                    new Choice('am', $("Amharic")),
                     new Choice('sw', $("Swahili")),
                     new Choice('so', $("Somali")),
                 ],

--- a/src/ussdapp.js
+++ b/src/ussdapp.js
@@ -180,7 +180,6 @@ go.app = function() {
                 choices: [
                     new Choice('en', $("English")),
                     new Choice('fr', $("French")),
-                    new Choice('am', $("Amharic")),
                     new Choice('sw', $("Swahili")),
                     new Choice('so', $("Somali")),
                 ],
@@ -1024,7 +1023,6 @@ go.app = function() {
                 choices: [
                     new Choice('en', $("English")),
                     new Choice('fr', $("French")),
-                    new Choice('am', $("Amharic")),
                     new Choice('sw', $("Swahili")),
                     new Choice('so', $("Somali")),
                 ],

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,7 +74,6 @@ go.utils = {
         var lang_map = {
             en: 'english',
             fr: 'french',
-            am: 'amharic',
             sw: 'swahili',
             so: 'somali'
         };

--- a/test/ussdapp.test.js
+++ b/test/ussdapp.test.js
@@ -1430,9 +1430,8 @@ describe("refugeerights app", function() {
                                 "Welcome! Would you like to find out about refugee and migrant rights in SA? First select your language:",
                                 "1. English",
                                 "2. French",
-                                "3. Amharic",
-                                "4. Swahili",
-                                "5. Somali"
+                                "3. Swahili",
+                                "4. Somali"
                             ].join('\n')
                         })
                         .run();


### PR DESCRIPTION
We cannot successfully send non-ASCII text over the networks used for this service, so we should remove Amharic from the language options.
