### PR TITLE
Fix scary hardcode language prefix length.

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -557,7 +557,8 @@ go.utils = {
                     var topics = [];
                     for (var topic in response.data) {
                         current_topic = response.data[topic];
-                        if (current_topic.topic.substr(0,5) === lang_prefix) {
+                        if (current_topic.topic.substr(0, lang_prefix.length)
+                            === lang_prefix) {
                             current_topic.topic = current_topic.topic.substr(5);
                             topics.push(current_topic);
                         }

--- a/go-app-ussd.js
+++ b/go-app-ussd.js
@@ -557,7 +557,8 @@ go.utils = {
                     var topics = [];
                     for (var topic in response.data) {
                         current_topic = response.data[topic];
-                        if (current_topic.topic.substr(0,5) === lang_prefix) {
+                        if (current_topic.topic.substr(0, lang_prefix.length)
+                            === lang_prefix) {
                             current_topic.topic = current_topic.topic.substr(5);
                             topics.push(current_topic);
                         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -550,7 +550,8 @@ go.utils = {
                     var topics = [];
                     for (var topic in response.data) {
                         current_topic = response.data[topic];
-                        if (current_topic.topic.substr(0,5) === lang_prefix) {
+                        if (current_topic.topic.substr(0, lang_prefix.length)
+                            === lang_prefix) {
                             current_topic.topic = current_topic.topic.substr(5);
                             topics.push(current_topic);
                         }


### PR DESCRIPTION
Currently the topic-by-language lookup unnecessarily assumes the language code is two letters.
