### PR TITLE
Upgrade to Grunt ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "devDependencies": {
     "mocha": "~1.18",
     "jshint": "~2.4.4",
+    "grunt": "^1.0.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.6.0",
-    "grunt": "~0.4.4",
     "grunt-mocha-test": "~0.10.0",
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-cli": "~0.1.13"

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "vumigo_v02": "~0.2"
   },
   "devDependencies": {
-    "mocha": "~1.18",
-    "jshint": "~2.4.4",
     "grunt": "^1.0.1",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-watch": "~0.6.0",
-    "grunt-mocha-test": "~0.10.0",
-    "grunt-contrib-jshint": "~0.9.2",
-    "grunt-cli": "~0.1.13"
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-concat": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-mocha-test": "^0.12.7",
+    "jshint": "~2.4.4",
+    "mocha": "~1.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-mocha-test": "^0.12.7",
-    "jshint": "~2.4.4",
-    "mocha": "~1.18"
+    "jshint": "^2.9.1",
+    "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
To avoid [this issue](https://github.com/praekelt/vumi-jssandbox-toolkit/issues/230).
